### PR TITLE
Update calculate parameter to use explicit array

### DIFF
--- a/src/main/matches/free-for-all/index.test.ts
+++ b/src/main/matches/free-for-all/index.test.ts
@@ -23,7 +23,7 @@ describe('FreeForAll', () => {
       new Player('1', 1000),
       new Player('2', 900)
     ])
-    const results = match.calculate('1', '2')
+    const results = match.calculate(['1', '2'])
 
     expect(results).toStrictEqual([
       {
@@ -42,7 +42,7 @@ describe('FreeForAll', () => {
       new Player('1', 1000),
       new Player('2', 900)
     ])
-    const results = match.calculate('2', '1')
+    const results = match.calculate(['2', '1'])
 
     expect(results).toStrictEqual([
       {
@@ -62,7 +62,7 @@ describe('FreeForAll', () => {
       new Player('2', 900),
       new Player('3', 800)
     ])
-    const results = match.calculate('1', '2', '3')
+    const results = match.calculate(['1', '2', '3'])
 
     expect(results).toStrictEqual([
       {
@@ -86,7 +86,7 @@ describe('FreeForAll', () => {
       new Player('2', 900),
       new Player('3', 800)
     ])
-    const results = match.calculate('2', '3', '1')
+    const results = match.calculate(['2', '3', '1'])
 
     expect(results).toStrictEqual([
       {
@@ -110,7 +110,7 @@ describe('FreeForAll', () => {
       new Player('2', 900),
       new Player('3', 800)
     ])
-    const results = match.calculate('3', '2', '1')
+    const results = match.calculate(['3', '2', '1'])
 
     expect(results).toStrictEqual([
       {
@@ -136,7 +136,7 @@ describe('FreeForAll', () => {
     }
 
     const results = match.calculate(
-      ...Array.from({ length: 100 }, (_, i) => (i + 1).toString())
+      Array.from({ length: 100 }, (_, i) => (i + 1).toString())
     )
 
     expect(results[0].elo).toBe(1016)
@@ -156,7 +156,7 @@ describe('FreeForAll', () => {
         {
           minPlayers: 3
         }
-      ).calculate('1', '2')
+      ).calculate(['1', '2'])
     }).toThrow(ErrorType.MIN_PLAYERS)
   })
 
@@ -165,7 +165,7 @@ describe('FreeForAll', () => {
       new FreeForAll([
         new Player('1', 1000),
         new Player('2', 900)
-      ]).calculate('1')
+      ]).calculate(['1'])
     }).toThrow(ErrorType.SIZE_MISMATCH)
   })
 })

--- a/src/main/matches/free-for-all/index.ts
+++ b/src/main/matches/free-for-all/index.ts
@@ -41,7 +41,7 @@ export class FreeForAll extends Match {
     return this
   }
 
-  calculate(...playerIds: string[]): PlayerResult[] {
+  calculate(playerIds: string[]): PlayerResult[] {
     if (this.completed) {
       throw new MatchError(ErrorType.MATCH_COMPLETE)
     }

--- a/src/main/matches/team-free-for-all/index.test.ts
+++ b/src/main/matches/team-free-for-all/index.test.ts
@@ -34,7 +34,7 @@ describe('TeamFreeForAll', () => {
   })
 
   test('calculates elo for team 1 winning', () => {
-    const results = match.calculate('1', '2', '3')
+    const results = match.calculate(['1', '2', '3'])
     expect(results).toStrictEqual([
       {
         id: '1',
@@ -79,7 +79,7 @@ describe('TeamFreeForAll', () => {
   })
 
   test('calculates elo for team 2 winning', () => {
-    const results = match.calculate('2', '1', '3')
+    const results = match.calculate(['2', '1', '3'])
     expect(results).toStrictEqual([
       {
         id: '1',
@@ -124,7 +124,7 @@ describe('TeamFreeForAll', () => {
   })
 
   test('calculates elo for team 3 winning', () => {
-    const results = match.calculate('3', '2', '1')
+    const results = match.calculate(['3', '2', '1'])
     expect(results).toStrictEqual([
       {
         id: '1',
@@ -176,7 +176,7 @@ describe('TeamFreeForAll', () => {
           new Team('2', [new Player('2', 900)])
         ],
         { minTeams: 3 }
-      ).calculate('1', '2')
+      ).calculate(['1', '2'])
     }).toThrow(ErrorType.MIN_TEAMS)
   })
 
@@ -187,7 +187,7 @@ describe('TeamFreeForAll', () => {
           new Team('1', [new Player('1', 1000)]),
           new Team('2', [new Player('2', 900)])
         ],
-      ).calculate('1')
+      ).calculate(['1'])
     }).toThrow(ErrorType.SIZE_MISMATCH)
   })
 })

--- a/src/main/matches/team-free-for-all/index.ts
+++ b/src/main/matches/team-free-for-all/index.ts
@@ -44,7 +44,7 @@ export class TeamFreeForAll extends Match {
     return this
   }
 
-  calculate(...teamIds: string[]): TeamResult[] {
+  calculate(teamIds: string[]): TeamResult[] {
     if (this.completed) {
       throw new MatchError(ErrorType.MATCH_COMPLETE)
     }


### PR DESCRIPTION
Use explicit array parameter instead of `...rest` with `calculate` method in `FreeForAll()` & `TeamFreeForAll()`.