### PR TITLE
Fix falsy elo check for opponent elo of 0

### DIFF
--- a/src/main/matches/free-for-all/index.test.ts
+++ b/src/main/matches/free-for-all/index.test.ts
@@ -135,6 +135,15 @@ describe('FreeForAll', () => {
     expect(results[99].elo).toBe(984)
   })
 
+  test('calculates elo for players with 0 elo', () => {
+    const match = new FreeForAll([new Player('1', 1000), new Player('2', 0), new Player('3', 500)])
+    const results = match.calculate(['1', '2', '3'])
+
+    expect(results[0].elo).toBeGreaterThan(0)
+    expect(results[1].elo).toBeDefined()
+    expect(results[2].elo).toBeDefined()
+  })
+
   test('throws error if trying to calculate when min players for match has not been reached', () => {
     expect(() => {
       new FreeForAll([new Player('1', 1000), new Player('2', 900)], {

--- a/src/main/matches/free-for-all/index.ts
+++ b/src/main/matches/free-for-all/index.ts
@@ -69,7 +69,7 @@ export class FreeForAll extends Match {
         if (i != j) {
           const opponentElo = players.get(playerIds[j])
 
-          if (!opponentElo) {
+          if (opponentElo === undefined) {
             throw new MatchError(ErrorType.MISSING_OPPONENT_ELO)
           }
 

--- a/src/main/matches/team-free-for-all/index.test.ts
+++ b/src/main/matches/team-free-for-all/index.test.ts
@@ -168,6 +168,18 @@ describe('TeamFreeForAll', () => {
     ])
   })
 
+  test('calculates elo for teams with 0 average elo', () => {
+    const match = new TeamFreeForAll([
+      new Team('1', [new Player('1', 1000), new Player('2', 900)]),
+      new Team('2', [new Player('3', 0), new Player('4', 0)]),
+      new Team('3', [new Player('5', 600), new Player('6', 500)])
+    ])
+    const results = match.calculate(['1', '2', '3'])
+
+    expect(results).toHaveLength(3)
+    expect(results[1].players).toBeDefined()
+  })
+
   test('throws error if calculating without min teams', () => {
     expect(() => {
       new TeamFreeForAll(

--- a/src/main/matches/team-free-for-all/index.ts
+++ b/src/main/matches/team-free-for-all/index.ts
@@ -70,7 +70,7 @@ export class TeamFreeForAll extends Match {
           if (i != j) {
             const opponentElo = teams.get(teamIds[j])
 
-            if (!opponentElo) {
+            if (opponentElo === undefined) {
               throw new MatchError(ErrorType.MISSING_OPPONENT_ELO)
             }
 


### PR DESCRIPTION
## Summary

- The `!opponentElo` check in `FreeForAll` and `TeamFreeForAll` incorrectly throws `MISSING_OPPONENT_ELO` when a player or team has an elo of 0, since `!0` evaluates to `true` in JavaScript
- Replaced `!opponentElo` with `opponentElo === undefined` to correctly distinguish a missing entry from a zero value
- Added tests for players and teams with 0 elo