### PR TITLE
Validate winner ID exists in duel and team-duel

### DIFF
--- a/src/main/matches/duel/index.test.ts
+++ b/src/main/matches/duel/index.test.ts
@@ -76,6 +76,14 @@ describe('Duel', () => {
     }).toThrow(ErrorType.MATCH_COMPLETE)
   })
 
+  test('throws error when calculating with non-existent player id', () => {
+    expect(() => {
+      const match = new Duel([new Player('1', 1000), new Player('2', 900)])
+
+      match.calculate('3')
+    }).toThrow(ErrorType.PLAYER_NOT_FOUND)
+  })
+
   test('throws error when calculating without 2 players', () => {
     expect(() => {
       const match = new Duel([new Player('1', 1000)])

--- a/src/main/matches/duel/index.ts
+++ b/src/main/matches/duel/index.ts
@@ -47,6 +47,10 @@ export class Duel extends Match {
       throw new MatchError(ErrorType.MIN_PLAYERS)
     }
 
+    if (!this.contestants.has(playerId)) {
+      throw new MatchError(ErrorType.PLAYER_NOT_FOUND)
+    }
+
     const players = this.contestantMapToEloMap()
 
     for (const [id, contestant] of this.contestants) {

--- a/src/main/matches/team-duel/index.test.ts
+++ b/src/main/matches/team-duel/index.test.ts
@@ -102,6 +102,12 @@ describe('TeamDuel', () => {
     ])
   })
 
+  test('throws error when calculating with non-existent team id', () => {
+    expect(() => {
+      match.calculate('3')
+    }).toThrow(ErrorType.TEAM_NOT_FOUND)
+  })
+
   test('throws error when calculating without 2 teams', () => {
     expect(() => {
       new TeamDuel([new Team('1')]).calculate('1')

--- a/src/main/matches/team-duel/index.ts
+++ b/src/main/matches/team-duel/index.ts
@@ -47,6 +47,10 @@ export class TeamDuel extends Match {
       throw new MatchError(ErrorType.MIN_TEAMS)
     }
 
+    if (!this.contestants.has(teamId)) {
+      throw new MatchError(ErrorType.TEAM_NOT_FOUND)
+    }
+
     const teams = this.contestantMapToEloMap()
 
     for (const [id, contestant] of this.contestants) {


### PR DESCRIPTION
## Summary

- Passing a non-existent player/team ID to `Duel.calculate()` or `TeamDuel.calculate()` previously caused both contestants to be silently treated as losers with no error
- Added validation that the winner ID exists in the match before calculating, throwing `PLAYER_NOT_FOUND` or `TEAM_NOT_FOUND` respectively
- Added tests for non-existent winner IDs in both match types