### PR TITLE
Use strict equality for loop index comparisons

### DIFF
--- a/src/main/matches/free-for-all/index.ts
+++ b/src/main/matches/free-for-all/index.ts
@@ -66,7 +66,7 @@ export class FreeForAll extends Match {
       let eloDiff = 0
 
       for (let j = 0; j < playerIds.length; j++) {
-        if (i != j) {
+        if (i !== j) {
           const opponentElo = players.get(playerIds[j])
 
           if (!opponentElo) {

--- a/src/main/matches/team-free-for-all/index.ts
+++ b/src/main/matches/team-free-for-all/index.ts
@@ -67,7 +67,7 @@ export class TeamFreeForAll extends Match {
         let eloDiff = 0
 
         for (let j = 0; j < teamIds.length; j++) {
-          if (i != j) {
+          if (i !== j) {
             const opponentElo = teams.get(teamIds[j])
 
             if (!opponentElo) {


### PR DESCRIPTION
## Summary

- Replaced loose equality (`!=`) with strict equality (`!==`) for loop index comparisons in `FreeForAll` and `TeamFreeForAll` calculate methods