### PR TITLE
Pass message to Error super constructor in BaseError

### DIFF
--- a/src/lib/error/index.ts
+++ b/src/lib/error/index.ts
@@ -1,10 +1,8 @@
 export class BaseError<T extends string> extends Error {
   name: T
-  message: string
 
   constructor(name: T, message: string) {
-    super()
+    super(message)
     this.name = name
-    this.message = message
   }
 }


### PR DESCRIPTION
## Summary

- `BaseError` was calling `super()` without passing the `message` argument, then manually assigning `this.message`
- This meant `Error.prototype.message` was initially empty, which can cause `err.stack` to omit the message in some environments
- Now calls `super(message)` and removes the redundant `message` field declaration since it is inherited from `Error`