### PR TITLE
Use prepublishOnly instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf ./dist",
     "start": "node dist/index.js",
     "test": "jest",
-    "prepublish": "pnpm clean && pnpm build"
+    "prepublishOnly": "pnpm clean && pnpm build"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",


### PR DESCRIPTION
## Summary

- Renamed the `prepublish` script to `prepublishOnly` to prevent the clean/build from running on `npm install` in older npm versions
- `prepublishOnly` only runs before `npm publish`, which is the intended behavior