### PR TITLE
Modernize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
       - name: Install modules
         run: pnpm install
       - name: Create build


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v2 to v4 (v2 uses deprecated Node 12)
- Replace `npm install -g pnpm` with `pnpm/action-setup@v4` for deterministic pnpm version management
- Add `actions/setup-node@v4` with Node 20 and pnpm dependency caching for faster CI runs