### PR TITLE
Add dedicated format:check script for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Run lint
         run: pnpm lint
       - name: Run format check
-        run: pnpm format --check
+        run: pnpm format:check
       - name: Run tests
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write src/**/*.ts",
+    "format:check": "prettier --check src/**/*.ts",
     "build": "rollup --config",
     "clean": "rm -rf ./dist",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary

- Added a `format:check` script that runs `prettier --check` explicitly, instead of relying on appending `--check` to the `format` script which uses `--write`
- Updated CI workflow to use `pnpm format:check` instead of `pnpm format --check`