### PR TITLE
Add eslint-config-prettier to ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
+import eslintConfigPrettier from 'eslint-config-prettier'
 const { configs: tsConfigs } = tsPlugin
 
 export default [
@@ -14,5 +15,6 @@ export default [
     rules: {
       ...tsConfigs.recommended.rules
     }
-  }
+  },
+  eslintConfigPrettier
 ]


### PR DESCRIPTION
## Summary

- `eslint-config-prettier` was installed as a dev dependency but was not included in the ESLint configuration
- Added it as a flat config entry to disable ESLint rules that conflict with Prettier formatting